### PR TITLE
Bugfix width

### DIFF
--- a/src/cz/alisma/alej/text/wrapping/LinePrinter.java
+++ b/src/cz/alisma/alej/text/wrapping/LinePrinter.java
@@ -66,9 +66,9 @@ public class LinePrinter {
                 output.println(aligner.format(line));
                 line.clear();
                 lengthSoFar = -1;
-            } else {
-                lengthSoFar++;
             }
+			
+            lengthSoFar++;
             line.add(word);
             lengthSoFar += word.length();
         }


### PR DESCRIPTION
LinePrinter could return an array of words which was too long
Fixed this off-by-one error